### PR TITLE
Added Botfront to the Chatbot builder section

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A curated list of awesome Chatbot services and resources.
 - [Botsociety](https://botsociety.io) - Design and preview your chabot before actually building it.
 
 ### Chatbot builder
+- [Botfront](https://botfront.io) - An open source platform to visually and intuitively build chatbots with Rasa.
 - [BotStar](https://wwww.botstar.com) - Design and Develop Chatbots for Messenger & Website. Visually.
 - [Flow XO](https://flowxo.com) - Bot + human messaging platform
 - [Gupshup](https://www.gupshup.io) - Comprehensive Platform to build Bots and use messaging Services


### PR DESCRIPTION
Botfront is an open source platform to build chatbots with Rasa, brining additional functionalities and ease of use to the rather complicated framework. I think it would be good to have it on this list.