### PR TITLE
Add Hal9

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ A curated list of awesome Chatbot services and resources.
 - [Chatfuel](https://chatfuel.com/) - Build a Facebook bot without coding
 - [m.io](https://m.io) - Enterprise bots for Slack, HipChat and Skype
 - [TuringRobot](http://www.tuling123.com/) - Platform for AI robots and AI robot OS
+- [Hal9](https://www.hal9.com/) - Python framework and service for generative AI applications
 
 ### Messaging services
 - [msg.ai](http://msg.ai/) - AI for Conversational Commerce


### PR DESCRIPTION
Hi, Javier here from Hal9.

[Hal9](https://www.hal9.com/) is a python framework (see [github.com/hal9ai/hal9](https://github.com/hal9ai/hal9)) and service to build and deploy chatbots for generative AI technologies like LLMs and diffusers.